### PR TITLE
Clean up body container layout and styling for web

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,7 @@ const theme = {
   ...MD3LightTheme,
   colors: {
     ...MD3LightTheme.colors,
-    background: '#f5f5f5',
+    background: '#000000',
   },
 };
 
@@ -56,13 +56,15 @@ export default function App() {
   }
 
   return (
-    <ErrorBoundary>
-      <PaperProvider theme={theme}>
-        <GameProvider>
-          <StatusBar style="dark" />
-          <AppNavigator />
-        </GameProvider>
-      </PaperProvider>
-    </ErrorBoundary>
+    <View style={{ flex: 1, backgroundColor: '#000000' }}>
+      <ErrorBoundary>
+        <PaperProvider theme={theme}>
+          <GameProvider>
+            <StatusBar style="dark" />
+            <AppNavigator />
+          </GameProvider>
+        </PaperProvider>
+      </ErrorBoundary>
+    </View>
   );
 }

--- a/app.json
+++ b/app.json
@@ -28,7 +28,8 @@
       "favicon": "./assets/favicon.png",
       "bundler": "metro",
       "publicPath": "/engine-kill/",
-      "output": "single"
+      "output": "single",
+      "backgroundColor": "#000000"
     },
     "experiments": {
       "baseUrl": "/engine-kill"

--- a/src/components/DamageTrack.tsx
+++ b/src/components/DamageTrack.tsx
@@ -180,7 +180,7 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 8,
     borderWidth: 3,
-    borderColor: '#000',
+    borderColor: '#000C03',
     borderBottomWidth: 0,
     gap: 16,
   },

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -27,15 +27,15 @@ export default function ScreenWrapper({ children, style }: ScreenWrapperProps) {
         onLoad={() => console.log('Texture overlay loaded successfully')}
       />
 
-      {/* Layer 3: Metal frame border */}
-      <ImageBackground
+      {/* Layer 3: Metal frame border (disabled) */}
+      {/* <ImageBackground
         source={require('../../assets/images/metal-frame.png')}
         style={styles.frameLayer}
         resizeMode="stretch"
         imageStyle={styles.frameImage}
         onError={(e) => console.error('Metal frame failed to load:', e.nativeEvent.error)}
         onLoad={() => console.log('Metal frame loaded successfully')}
-      />
+      /> */}
 
       {/* Layer 4: Content area */}
       <View style={styles.contentArea}>
@@ -48,6 +48,9 @@ export default function ScreenWrapper({ children, style }: ScreenWrapperProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    width: '100%',
+    maxWidth: 800,
+    alignSelf: 'center',
     position: 'relative',
   },
 
@@ -68,6 +71,8 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+    width: '100%',
+    height: '100%',
     opacity: 0.5, // Make texture more visible
     zIndex: 1,
   },

--- a/src/screens/UnitEditScreen.tsx
+++ b/src/screens/UnitEditScreen.tsx
@@ -302,7 +302,7 @@ export default function UnitEditScreen({
               placeholderTextColor={colors.textMuted}
               style={styles.titleInput}
               autoCorrect={false}
-              autoCapitalize="words"
+              autoCapitalize="characters"
               returnKeyType="done"
               blurOnSubmit
               numberOfLines={1}
@@ -315,20 +315,10 @@ export default function UnitEditScreen({
           </Text>
         </View>
 
-        {isLg ? (
-          <View style={styles.mainRowLg}>
-            <StatsPanel unit={unit} style={styles.statsPanelLg} />
-            <View style={styles.rightColumnLg}>{rightPanel}</View>
-          </View>
-        ) : (
-          <>
-            {/* Mobile-first: stack sections to avoid overlap */}
-            <View style={styles.statsSection}>
-              <StatsPanel unit={unit} style={styles.statsPanel} />
-            </View>
-            {rightPanel}
-          </>
-        )}
+        <View style={styles.statsSection}>
+          <StatsPanel unit={unit} style={styles.statsPanel} />
+        </View>
+        {rightPanel}
 
         {/* Damage Tracks - Below the main row */}
         <View style={styles.damageSection}>
@@ -465,14 +455,12 @@ const styles = StyleSheet.create({
   },
   content: {
     padding: spacing.lg,
-    maxWidth: '98%', // Constrain content width to ensure borders are visible
-    alignSelf: 'center', // Center the content
   },
   header: {
     marginBottom: spacing.lg,
     paddingBottom: spacing.md,
     borderBottomWidth: 2,
-    borderBottomColor: colors.border,
+    borderBottomColor: '#00A323',
   },
   headerTopRow: {
     flexDirection: 'row',
@@ -483,21 +471,25 @@ const styles = StyleSheet.create({
     marginRight: spacing.xs,
   },
   title: {
-    color: colors.text,
-    fontSize: fontSize.xxl,
+    color: '#9AFCAF',
+    fontSize: 32,
     fontWeight: 'bold',
+    fontFamily: 'RobotoMono_700Bold',
+    textTransform: 'uppercase',
     flex: 1,
   },
   titleInput: {
-    color: colors.text,
-    fontSize: fontSize.xxl,
+    color: '#9AFCAF',
+    fontSize: 32,
     fontWeight: 'bold',
+    fontFamily: 'RobotoMono_700Bold',
+    textTransform: 'uppercase',
     flex: 1,
     paddingVertical: 0,
     paddingHorizontal: 0,
   },
   subtitle: {
-    color: colors.textMuted,
+    color: '#9AFCAF',
     fontSize: fontSize.md,
     marginTop: spacing.xs,
   },
@@ -514,7 +506,8 @@ const styles = StyleSheet.create({
   },
   statsPanelLg: {
     marginRight: spacing.lg,
-    flex: 0,
+    flexShrink: 0,
+    width: 350,
   },
   rightColumnLg: {
     flex: 1,


### PR DESCRIPTION
- Move maxWidth constraint from ScrollView content to ScreenWrapper (800px)
- Set black background on App root and PaperProvider for wide viewports
- Disable metal frame overlay in ScreenWrapper
- Make stats/reactor layout always vertical (remove lg side-by-side)
- Update titan title: RobotoMono font, uppercase, #9AFCAF color, 32px
- Update subtitle color to #9AFCAF
- Update header divider color to #00A323
- Update DamageTrack container border to #000C03