### PR TITLE
Weapon Mount Tab Update

### DIFF
--- a/src/components/WeaponMountTabs.tsx
+++ b/src/components/WeaponMountTabs.tsx
@@ -1,0 +1,451 @@
+import React, { useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Weapon } from '../models/Unit';
+
+type MountKey = 'leftWeapon' | 'rightWeapon' | 'carapaceWeapon';
+
+interface WeaponMountItem {
+  key: MountKey;
+  label: string;
+  weapon: Weapon | null;
+}
+
+interface WeaponMountTabsProps {
+  mounts: WeaponMountItem[];
+  onChangeWeapon: (mount: MountKey) => void;
+  onToggleDisabled: (mount: MountKey) => void;
+}
+
+const fmtRange = (v: number | string | undefined | null): string => {
+  if (v === '-' || v === '' || v === null || v === undefined) return '—';
+  if (typeof v === 'number') return `${v}"`;
+  const t = String(v).trim();
+  if (!t || t === '-') return '—';
+  if (t === 'T' || t.toLowerCase() === 'template') return 'T';
+  if (t.includes('"')) return t;
+  if (/^-?\d+(\.\d+)?$/.test(t)) return `${t}"`;
+  return t;
+};
+
+export default function WeaponMountTabs({ mounts, onChangeWeapon, onToggleDisabled }: WeaponMountTabsProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  if (!mounts.length) return null;
+
+  const safeIndex = Math.min(selectedIndex, mounts.length - 1);
+  const selectedMount = mounts[safeIndex];
+  const weapon = selectedMount?.weapon ?? null;
+  const isDisabled = weapon?.status === 'disabled';
+  const isDestroyed = weapon?.status === 'destroyed';
+
+  return (
+    <View style={styles.container}>
+      {/* Tab bar */}
+      <View style={styles.tabBar}>
+        {mounts.map((m, i) => {
+          const isActive = i === safeIndex;
+          const hasAlert = m.weapon?.status === 'disabled' || m.weapon?.status === 'destroyed';
+          const alertColor = m.weapon?.status === 'destroyed' ? '#ff4444' : '#ff6a00';
+          return (
+            <TouchableOpacity
+              key={m.key}
+              style={[styles.tab, isActive && styles.tabActive]}
+              onPress={() => setSelectedIndex(i)}
+              activeOpacity={0.8}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+            >
+              <View style={styles.tabContents}>
+                <Text style={[styles.tabLabel, hasAlert && { color: alertColor }]}>
+                  {m.label}
+                </Text>
+                {hasAlert && (
+                  <View style={[styles.badge, { backgroundColor: alertColor }]} />
+                )}
+              </View>
+              {isActive && <View style={styles.indicator} />}
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {/* Tab bar bottom divider */}
+      <View style={styles.tabDivider} />
+
+      {/* Content panel */}
+      <View style={styles.panel}>
+        {weapon ? (
+          <>
+            {/* Weapon name + points */}
+            <View style={styles.nameBlock}>
+              <Text style={styles.weaponName}>{weapon.name}</Text>
+              <Text style={styles.weaponPoints}>{weapon.points} Points</Text>
+            </View>
+
+            {/* Range table */}
+            <View style={styles.rangeBlock}>
+              <View style={styles.rangeDivider} />
+
+              {/* Short row — includes IN / ACC column headers */}
+              <View style={[styles.rangeRow, styles.rangeRowShort]}>
+                <View style={styles.rangeLabelCell}>
+                  {/* Spacer to push label down to align with value boxes */}
+                  <Text style={styles.rangeHeaderSpacer}>{' '}</Text>
+                  <View style={styles.rangeValueBox}>
+                    <Text style={styles.rangeLabel}>Short</Text>
+                  </View>
+                </View>
+                <View style={styles.rangeColWithHeader}>
+                  <Text style={styles.rangeHeader}>IN</Text>
+                  <View style={styles.rangeValueBox}>
+                    <Text style={styles.rangeValue}>{fmtRange(weapon.shortRange)}</Text>
+                  </View>
+                </View>
+                <View style={styles.rangeColWithHeader}>
+                  <Text style={styles.rangeHeader}>ACC</Text>
+                  <View style={styles.rangeValueBox}>
+                    <Text style={styles.rangeValue}>{weapon.accuracyShort ?? '—'}</Text>
+                  </View>
+                </View>
+              </View>
+
+              {/* Long row — values only */}
+              <View style={styles.rangeRow}>
+                <View style={styles.rangeLabelCell}>
+                  <View style={styles.rangeValueBox}>
+                    <Text style={styles.rangeLabel}>Long</Text>
+                  </View>
+                </View>
+                <View style={styles.rangeColValue}>
+                  <View style={styles.rangeValueBox}>
+                    <Text style={styles.rangeValue}>{fmtRange(weapon.longRange)}</Text>
+                  </View>
+                </View>
+                <View style={styles.rangeColValue}>
+                  <View style={styles.rangeValueBox}>
+                    <Text style={styles.rangeValue}>{weapon.accuracyLong ?? '—'}</Text>
+                  </View>
+                </View>
+              </View>
+
+              <View style={styles.rangeDivider} />
+            </View>
+
+            {/* Dice / Str + Traits + Special Rules */}
+            <View style={styles.statsBlock}>
+              <View style={styles.statsRow}>
+                <Text style={styles.statLabel}>Dice | Str:</Text>
+                <Text style={styles.statValue}>{weapon.dice} | {weapon.strength}</Text>
+              </View>
+
+              {weapon.traits && weapon.traits.length > 0 && (
+                <View style={styles.traitBlock}>
+                  <Text style={styles.traitsBold}>Traits</Text>
+                  {weapon.traits.map((t, idx) => (
+                    <Text key={idx} style={styles.traitItem}>• {t}</Text>
+                  ))}
+                </View>
+              )}
+
+              {weapon.specialRules && weapon.specialRules.length > 0 && (
+                <View style={styles.traitBlock}>
+                  <Text style={styles.traitsBold}>Special Rules</Text>
+                  {weapon.specialRules.map((r, idx) => (
+                    <Text key={idx} style={styles.traitItem}>• {r}</Text>
+                  ))}
+                </View>
+              )}
+            </View>
+
+            {/* Action buttons */}
+            <View style={styles.actions}>
+              {isDestroyed ? (
+                <View style={[styles.actionButton, styles.destroyedButton]}>
+                  <Text style={styles.destroyedButtonText}>WEAPON DESTROYED</Text>
+                </View>
+              ) : (
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.disableButton]}
+                  onPress={() => onToggleDisabled(selectedMount.key)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.disableButtonText}>
+                    {isDisabled ? 'REPAIR' : 'DISABLE'}
+                  </Text>
+                </TouchableOpacity>
+              )}
+              <TouchableOpacity
+                style={[styles.actionButton, styles.changeButton]}
+                onPress={() => onChangeWeapon(selectedMount.key)}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.changeButtonText}>CHANGE WEAPON</Text>
+              </TouchableOpacity>
+            </View>
+          </>
+        ) : (
+          /* Empty state */
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyText}>No weapon equipped</Text>
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.actionButton, styles.addButton]}
+                onPress={() => onChangeWeapon(selectedMount.key)}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.addButtonText}>ADD WEAPON</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(0, 152, 33, 0.15)',
+  },
+
+  // ── Tabs ──────────────────────────────────────────────────────────────────
+  tabBar: {
+    flexDirection: 'row',
+    backgroundColor: 'rgba(0, 8, 2, 0.75)',
+    height: 48,
+  },
+  tab: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 8, 2, 0.75)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    overflow: 'hidden',
+  },
+  tabActive: {
+    backgroundColor: '#004b10',
+  },
+  tabContents: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  tabLabel: {
+    color: '#9dffb2',
+    fontSize: 14,
+    fontFamily: 'RobotoMono_700Bold',
+    letterSpacing: 0.1,
+    textAlign: 'center',
+  },
+  badge: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  indicator: {
+    position: 'absolute',
+    bottom: 0,
+    left: 2,
+    right: 2,
+    height: 3,
+    backgroundColor: '#9dffb2',
+    borderTopLeftRadius: 100,
+    borderTopRightRadius: 100,
+  },
+  tabDivider: {
+    height: 1,
+    backgroundColor: 'rgba(0, 163, 35, 0.6)',
+  },
+
+  // ── Panel ─────────────────────────────────────────────────────────────────
+  panel: {
+    backgroundColor: 'rgba(0, 8, 2, 0.75)',
+    borderBottomLeftRadius: 8,
+    borderBottomRightRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 24,
+    gap: 24,
+  },
+
+  // ── Weapon name + points ──────────────────────────────────────────────────
+  nameBlock: {
+    gap: 2,
+  },
+  weaponName: {
+    color: '#8be39d',
+    fontSize: 24,
+    fontFamily: 'RobotoMono_700Bold',
+    lineHeight: 32,
+  },
+  weaponPoints: {
+    color: '#9afcaf',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+    letterSpacing: 0.4,
+  },
+
+  // ── Range table ───────────────────────────────────────────────────────────
+  rangeBlock: {
+    gap: 8,
+  },
+  rangeDivider: {
+    height: 1,
+    backgroundColor: 'rgba(0, 163, 35, 0.6)',
+    borderRadius: 5,
+  },
+  rangeRow: {
+    flexDirection: 'row',
+    gap: 4,
+    alignItems: 'flex-start',
+  },
+  rangeRowShort: {
+    // Short row is taller to accommodate the column headers
+    height: 50,
+  },
+  rangeLabelCell: {
+    width: 40,
+    justifyContent: 'center',
+  },
+  rangeHeaderSpacer: {
+    height: 14,
+    fontSize: 11,
+    opacity: 0,
+  },
+  rangeColWithHeader: {
+    flex: 1,
+    gap: 4,
+    alignItems: 'center',
+  },
+  rangeColValue: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  rangeHeader: {
+    color: '#8be49d',
+    fontSize: 11,
+    fontFamily: 'RobotoMono_400Regular',
+    textAlign: 'center',
+    lineHeight: 14,
+  },
+  rangeLabel: {
+    color: '#8be39d',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+  },
+  rangeValueBox: {
+    height: 32,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 8,
+  },
+  rangeValue: {
+    color: '#9dffb2',
+    fontSize: 16,
+    fontFamily: 'RobotoMono_700Bold',
+    textAlign: 'center',
+  },
+
+  // ── Stats + Traits ────────────────────────────────────────────────────────
+  statsBlock: {
+    gap: 8,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  statLabel: {
+    color: '#8be39d',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+    width: 80,
+  },
+  statValue: {
+    color: '#8be39d',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+  },
+  traitBlock: {
+    gap: 2,
+  },
+  traitsBold: {
+    color: '#8be39d',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_700Bold',
+  },
+  traitItem: {
+    color: '#8be39d',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+    lineHeight: 15.6,
+  },
+
+  // ── Action buttons ────────────────────────────────────────────────────────
+  actions: {
+    flexDirection: 'row',
+    gap: 8,
+    width: '100%',
+  },
+  actionButton: {
+    flex: 1,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 48,
+    overflow: 'hidden',
+  },
+  disableButton: {
+    backgroundColor: '#0d120e',
+    borderWidth: 2,
+    borderColor: '#009821',
+  },
+  disableButtonText: {
+    color: '#9dffb2',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+    letterSpacing: 0.5,
+  },
+  destroyedButton: {
+    backgroundColor: 'rgba(200, 0, 0, 0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(200, 0, 0, 0.3)',
+  },
+  destroyedButtonText: {
+    color: '#ff6666',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_700Bold',
+    letterSpacing: 0.5,
+  },
+  changeButton: {
+    backgroundColor: '#0d120e',
+  },
+  changeButtonText: {
+    color: '#9dffb2',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+    letterSpacing: 0.5,
+  },
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+  emptyState: {
+    gap: 16,
+  },
+  emptyText: {
+    color: '#8be39d',
+    fontSize: 14,
+    fontFamily: 'RobotoMono_400Regular',
+    opacity: 0.5,
+  },
+  addButton: {
+    backgroundColor: '#0d120e',
+    borderWidth: 2,
+    borderColor: '#009821',
+  },
+  addButtonText: {
+    color: '#9dffb2',
+    fontSize: 12,
+    fontFamily: 'RobotoMono_400Regular',
+    letterSpacing: 0.5,
+  },
+});

--- a/src/screens/UnitEditScreen.tsx
+++ b/src/screens/UnitEditScreen.tsx
@@ -9,8 +9,7 @@ import IonShieldSavesDisplay from '../components/IonShieldSavesDisplay';
 import VoidShieldDisplay from '../components/VoidShieldDisplay';
 import PlasmaReactorDisplay from '../components/PlasmaReactorDisplay';
 import StatsPanel from '../components/StatsPanel';
-import WeaponMount from '../components/WeaponMount';
-import WeaponBottomSheet from '../components/WeaponBottomSheet';
+import WeaponMountTabs from '../components/WeaponMountTabs';
 import WeaponSelectionModal from '../components/WeaponSelectionModal';
 import ScreenWrapper from '../components/ScreenWrapper';
 import { useBannerTemplates } from '../hooks/useBannerTemplates';
@@ -44,7 +43,6 @@ export default function UnitEditScreen({
   const [isBannerUpgradePickerOpen, setIsBannerUpgradePickerOpen] = useState(false);
   const [bannerWeaponSlotPicking, setBannerWeaponSlotPicking] = useState<number | null>(null);
   const [selectedMount, setSelectedMount] = useState<'leftWeapon' | 'rightWeapon' | 'carapaceWeapon' | null>(null);
-  const [weaponSheetMount, setWeaponSheetMount] = useState<'leftWeapon' | 'rightWeapon' | 'carapaceWeapon' | null>(null);
   const [nameDraft, setNameDraft] = useState('');
 
   const unit = state.units.find((u) => u.id === unitId);
@@ -271,33 +269,17 @@ export default function UnitEditScreen({
     </>
   );
 
-  const openWeaponModal = (mount: 'leftWeapon' | 'rightWeapon' | 'carapaceWeapon') => {
+  const handleOpenWeaponSelection = (mount: 'leftWeapon' | 'rightWeapon' | 'carapaceWeapon') => {
     setSelectedMount(mount);
     setWeaponModalVisible(true);
   };
 
-  const handleMountPress = (mount: 'leftWeapon' | 'rightWeapon' | 'carapaceWeapon') => {
+  const handleToggleDisabled = (mount: 'leftWeapon' | 'rightWeapon' | 'carapaceWeapon') => {
     if (!unit) return;
-    if (unit[mount]) {
-      setWeaponSheetMount(mount);
-    } else {
-      openWeaponModal(mount);
-    }
-  };
-
-  const handleToggleFromSheet = () => {
-    if (!weaponSheetMount || !unit) return;
-    const weapon = unit[weaponSheetMount];
+    const weapon = unit[mount];
     if (!weapon) return;
     const nextStatus = weapon.status === 'disabled' ? 'ready' : 'disabled';
-    updateWeapon(unitId, weaponSheetMount, { ...weapon, status: nextStatus });
-    setWeaponSheetMount(null);
-  };
-
-  const handleChangeFromSheet = () => {
-    const mount = weaponSheetMount;
-    setWeaponSheetMount(null);
-    if (mount) openWeaponModal(mount);
+    updateWeapon(unitId, mount, { ...weapon, status: nextStatus });
   };
 
   const addUpgradeToBanner = (upgradeId: string) => {
@@ -488,18 +470,15 @@ export default function UnitEditScreen({
         </View>
 
       {/* Weapon Mounts */}
-      <View style={styles.weaponSection}>
-        <View style={styles.weaponRow}>
-          {weaponMounts.map((m) => (
-            <WeaponMount
-              key={m.key}
-              label={m.label}
-              weapon={m.weapon}
-              onPress={() => handleMountPress(m.key)}
-            />
-          ))}
+      {weaponMounts.length > 0 && (
+        <View style={styles.weaponSection}>
+          <WeaponMountTabs
+            mounts={weaponMounts}
+            onChangeWeapon={handleOpenWeaponSelection}
+            onToggleDisabled={handleToggleDisabled}
+          />
         </View>
-      </View>
+      )}
 
         {/* Banner: Wargear & Upgrades */}
         {unit.unitType === 'banner' && (
@@ -692,18 +671,7 @@ export default function UnitEditScreen({
           />
         )}
 
-        {/* Weapon Bottom Sheet — outside ScrollView so it's constrained to ScreenWrapper */}
-        {weaponSheetMount && unit?.[weaponSheetMount] && (
-          <WeaponBottomSheet
-            visible={!!weaponSheetMount}
-            mountLabel={weaponMounts.find((m) => m.key === weaponSheetMount)?.label ?? ''}
-            weapon={unit[weaponSheetMount]!}
-            onClose={() => setWeaponSheetMount(null)}
-            onChangeWeapon={handleChangeFromSheet}
-            onToggleDisabled={handleToggleFromSheet}
-          />
-        )}
-        </View>
+</View>
     </SafeAreaView>
     </ScreenWrapper>
   );
@@ -901,13 +869,7 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
   },
   weaponSection: {
-    backgroundColor: 'rgba(0, 152, 33, 0.15)',
-    padding: 16,
     marginTop: spacing.lg,
-  },
-  weaponRow: {
-    flexDirection: 'row',
-    gap: 8,
   },
   errorText: {
     color: colors.text,


### PR DESCRIPTION
## Summary

- Replaces the row of weapon mount buttons with a tabbed layout — one tab per mount (L. ARM, CARAPACE, R. ARM)
- Active tab is highlighted with a green background and indicator bar; disabled/destroyed weapons show an orange badge dot on their tab
- Weapon details (name, points, range table, dice/str, traits) are now displayed inline in a panel below the tabs, replacing the WeaponBottomSheet slide-up
- DISABLE / REPAIR and CHANGE WEAPON actions are available directly in the inline panel
- Empty mounts show a full-width ADD WEAPON button; weapon selection still uses the existing WeaponSelectionModal bottom sheet

## Test Plan

- [ ] Open a titan unit and verify all weapon mount tabs render correctly
- [ ] Tap each tab and confirm the correct weapon info appears in the panel below
- [ ] Confirm the active tab highlights green with the indicator bar
- [ ] Equip a weapon, disable it, and verify the orange badge appears on its tab
- [ ] Tap DISABLE and confirm it toggles to REPAIR (and back)
- [ ] Tap CHANGE WEAPON and confirm the WeaponSelectionModal opens
- [ ] Remove a weapon and confirm the empty state renders with ADD WEAPON button at full width
- [ ] Tap ADD WEAPON and confirm the WeaponSelectionModal opens
- [ ] Verify titans without a carapace weapon only show two tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)