### PR TITLE
Split Dice/Str into separate labeled rows in weapon displays

### DIFF
--- a/src/components/WeaponBottomSheet.tsx
+++ b/src/components/WeaponBottomSheet.tsx
@@ -147,8 +147,12 @@ export default function WeaponBottomSheet({
             <View style={styles.divider} />
 
             <View style={styles.statsRow}>
-              <Text style={styles.statLabel}>Dice | Str:</Text>
-              <Text style={styles.statValue}>{weapon.dice} | {weapon.strength}</Text>
+              <Text style={styles.statLabel}>Dice:</Text>
+              <Text style={styles.statValue}>{weapon.dice}</Text>
+            </View>
+            <View style={styles.statsRow}>
+              <Text style={styles.statLabel}>Str:</Text>
+              <Text style={styles.statValue}>{weapon.strength}</Text>
             </View>
 
             {weapon.traits && weapon.traits.length > 0 && (

--- a/src/components/WeaponMountTabs.tsx
+++ b/src/components/WeaponMountTabs.tsx
@@ -163,8 +163,12 @@ export default function WeaponMountTabs({
             {/* Dice / Str + Traits + Special Rules */}
             <View style={styles.statsBlock}>
               <View style={styles.statsRow}>
-                <Text style={styles.statLabel}>Dice | Str:</Text>
-                <Text style={styles.statValue}>{weapon.dice} | {weapon.strength}</Text>
+                <Text style={styles.statLabel}>Dice:</Text>
+                <Text style={styles.statValue}>{weapon.dice}</Text>
+              </View>
+              <View style={styles.statsRow}>
+                <Text style={styles.statLabel}>Str:</Text>
+                <Text style={styles.statValue}>{weapon.strength}</Text>
               </View>
 
               {weapon.traits && weapon.traits.length > 0 && (

--- a/src/components/WeaponSelectionModal.tsx
+++ b/src/components/WeaponSelectionModal.tsx
@@ -149,9 +149,8 @@ export default function WeaponSelectionModal({
               </View>
 
               {/* Dice / Str */}
-              <Text style={styles.diceStat}>
-                Dice | Str: {weapon.dice} | {weapon.strength}
-              </Text>
+              <Text style={styles.diceStat}>Dice: {weapon.dice}</Text>
+              <Text style={styles.diceStat}>Str: {weapon.strength}</Text>
 
               {/* Traits */}
               {weapon.traits.length > 0 && (


### PR DESCRIPTION
## Summary
- Replaces the ambiguous `Dice | Str: X | Y` combined label with two explicit rows (`Dice: X` / `Str: Y`)
- Applied consistently across `WeaponMountTabs`, `WeaponBottomSheet`, and `WeaponSelectionModal`
- No new styles added — reuses existing `statLabel`/`statValue` and `diceStat` patterns

## Test plan
- [ ] Open any titan with a weapon equipped → verify weapon detail tab shows `Dice:` and `Str:` as separate rows
- [ ] Tap weapon name to open `WeaponBottomSheet` → verify same layout
- [ ] Tap CHANGE WEAPON → verify selection modal shows separate rows for each weapon
- [ ] Confirm traits and special rules still render correctly below the stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)